### PR TITLE
パッケージに余分なファイルが含まれないように

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+.github/
+*.test.js
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "yellow-eyed",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "jest": "^26.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yellow-eyed",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "iRemocon Wi-Fi (IRM-03WLA) コマンド送信ライブラリ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`npm pack` の結果
```
npm notice 
npm notice 📦  yellow-eyed@0.3.1
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE     
npm notice 800B  README.md   
npm notice 1.8kB index.js    
npm notice 581B  package.json
npm notice === Tarball Details === 
npm notice name:          yellow-eyed                             
npm notice version:       0.3.1                                   
npm notice filename:      yellow-eyed-0.3.1.tgz                   
npm notice package size:  2.4 kB                                  
npm notice unpacked size: 4.3 kB                                  
npm notice shasum:        1a9e982bc7e29e665df288c8d5224a06dff1eeae
npm notice integrity:     sha512-r+yBviIYOFNoX[...]k1z+j8tioXwkw==
npm notice total files:   4                                       
npm notice 
```